### PR TITLE
Export to collector instead of honeycomb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc79add46364183ece1a4542592ca593e6421c60807232f5b8f7a31703825d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry_api",
+ "reqwest",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,8 +1513,10 @@ dependencies = [
  "futures-util",
  "http",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "prost",
+ "reqwest",
  "thiserror",
  "tokio",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,12 @@ tracing-opentelemetry = "0.18.0"
 tracing-futures = "0.2.5"
 tracing-tree = "0.2.2"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio", "metrics"] }
-opentelemetry-otlp = { version = "0.11.0", features = ["tonic", "tls", "tls-roots"] }
+opentelemetry-otlp = { version = "0.11.0", features = [
+  "reqwest-client",
+  "http-proto",
+  "tls",
+  "tls-roots",
+] }
 tonic = "0.8.3"
 warp = {version = "0.3.3", features = ["compression"]}
 dotenv = "0.15.0"

--- a/src/setup_tracing.rs
+++ b/src/setup_tracing.rs
@@ -2,8 +2,6 @@ use opentelemetry::sdk::trace as sdktrace;
 use opentelemetry_otlp::WithExportConfig;
 use std::collections::HashMap;
 use std::env;
-use std::str::FromStr;
-use tonic::metadata::{MetadataKey, MetadataMap};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
@@ -15,7 +13,7 @@ const HEADER_PREFIX: &str = "OTEL_METADATA_";
 // OTEL_METADATA_AUTHORIZATION = otel collector basic auth
 // OTEL_EXPORTER_OTLP_ENDPOINT = http://otel-collector.csbops.io
 fn init_opentelemetry() -> Option<sdktrace::Tracer> {
-    let mut headers = HashMap::new();
+    let mut headers: HashMap<String, String> = HashMap::new();
     for (key, value) in env::vars()
         .filter(|(name, _)| name.starts_with(HEADER_PREFIX))
         .map(|(name, value)| {

--- a/src/setup_tracing.rs
+++ b/src/setup_tracing.rs
@@ -1,5 +1,6 @@
 use opentelemetry::sdk::trace as sdktrace;
 use opentelemetry_otlp::WithExportConfig;
+use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
 use tonic::metadata::{MetadataKey, MetadataMap};
@@ -11,10 +12,10 @@ use tracing_tree::HierarchicalLayer;
 const HEADER_PREFIX: &str = "OTEL_METADATA_";
 
 // Used environment variables
-// OTEL_METADATA_X_HONEYCOMB_TEAM = honeycomb api key
-// OTEL_EXPORTER_OTLP_ENDPOINT = https://api.honeycomb.io:443
+// OTEL_METADATA_AUTHORIZATION = otel collector basic auth
+// OTEL_EXPORTER_OTLP_ENDPOINT = http://otel-collector.csbops.io
 fn init_opentelemetry() -> Option<sdktrace::Tracer> {
-    let mut metadata = MetadataMap::new();
+    let mut headers = HashMap::new();
     for (key, value) in env::vars()
         .filter(|(name, _)| name.starts_with(HEADER_PREFIX))
         .map(|(name, value)| {
@@ -27,7 +28,7 @@ fn init_opentelemetry() -> Option<sdktrace::Tracer> {
         })
     {
         println!("Found tracing metadata env variable: {}", key);
-        metadata.insert(MetadataKey::from_str(&key).unwrap(), value.parse().unwrap());
+        headers.insert(key, value.parse().unwrap());
     }
 
     if let Err(_err) = env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
@@ -40,10 +41,13 @@ fn init_opentelemetry() -> Option<sdktrace::Tracer> {
         env::set_var("OTEL_SERVICE_NAME", "sandpack-cdn");
     }
 
+    let mut headers = HashMap::new();
+
+    // First, create a OTLP exporter builder.
     let exporter = opentelemetry_otlp::new_exporter()
-        .tonic()
-        .with_env()
-        .with_metadata(dbg!(metadata));
+        .http()
+        .with_headers(headers)
+        .with_env();
 
     match opentelemetry_otlp::new_pipeline()
         .tracing()


### PR DESCRIPTION
Export tracing data to our collector instead of Honeycomb in order to use tail-based sampling.

After merge, please also update this PR https://github.com/codesandbox/microservices-gitops/pull/2