### PR TITLE
feat: Fetch missing packages from upstream npm registry

### DIFF
--- a/src/app_error.rs
+++ b/src/app_error.rs
@@ -61,6 +61,8 @@ pub enum ServerError {
     NotChanged,
     #[error("Invalid query")]
     InvalidQuery,
+    #[error("Unexpected error")]
+    UnexpectedError { message: String },
     #[error("MessagePack Decode Error")]
     MessagePackDecodeError(#[from] rmp_serde::decode::Error),
 }

--- a/src/app_error.rs
+++ b/src/app_error.rs
@@ -30,6 +30,8 @@ pub enum ServerError {
     SWCParseError { message: String },
     #[error("Could not download tarball package")]
     TarballDownloadError { status_code: u16, url: String },
+    #[error("Could not download package metadata")]
+    PackageMetadataDownloadError { status_code: u16, url: String },
     #[error("Could not download npm package manifest")]
     NpmManifestDownloadError {
         status_code: u16,

--- a/src/npm/dep_tree_builder.rs
+++ b/src/npm/dep_tree_builder.rs
@@ -6,9 +6,7 @@ use std::{
 use node_semver::{Range, Version};
 use tracing::{error, info};
 
-use crate::{
-    app_error::ServerError, npm_replicator::registry::NpmRocksDB,
-};
+use crate::{app_error::ServerError, npm_replicator::registry::NpmRocksDB};
 
 #[derive(Clone, Eq, Hash, PartialEq, Debug)]
 pub enum DepRange {
@@ -132,8 +130,13 @@ impl DepTreeBuilder {
                     );
                 }
                 None => {
-                    error!("Invalid package specifier");
-                    return Err(ServerError::InvalidPackageSpecifier);
+                    // If it contains a colon, it's a special specifier and we should just ignore those
+                    if tag.contains(':') {
+                        return Ok(transient_deps);
+                    } else {
+                        error!("Invalid package specifier");
+                        return Err(ServerError::InvalidPackageSpecifier);
+                    }
                 }
             }
         } else if let DepRange::Range(original_range) = &request.range {

--- a/src/npm/dep_tree_builder.rs
+++ b/src/npm/dep_tree_builder.rs
@@ -6,9 +6,11 @@ use std::{
 use node_semver::{Range, Version};
 use tracing::{error, info};
 
-use crate::{app_error::ServerError, npm_replicator::registry::NpmRocksDB};
+use crate::{
+    app_error::ServerError, npm_replicator::registry::NpmRocksDB,
+};
 
-#[derive(Eq, Hash, PartialEq, Debug)]
+#[derive(Clone, Eq, Hash, PartialEq, Debug)]
 pub enum DepRange {
     Range(Range),
     Tag(String),
@@ -40,7 +42,7 @@ impl fmt::Display for DepRange {
     }
 }
 
-#[derive(Eq, Hash, PartialEq, Debug)]
+#[derive(Clone, Eq, Hash, PartialEq, Debug)]
 pub struct DepRequest {
     name: String,
     range: DepRange,

--- a/src/npm/mod.rs
+++ b/src/npm/mod.rs
@@ -1,2 +1,3 @@
 pub mod package_content;
 pub mod dep_tree_builder;
+pub mod package_data;

--- a/src/npm/package_data.rs
+++ b/src/npm/package_data.rs
@@ -36,10 +36,6 @@ pub struct PackageVersion {
     pub dist: PackageDist,
     #[serde(default)]
     pub dependencies: BTreeMap<String, String>,
-    #[serde(rename = "devDependencies", default)]
-    pub dev_dependencies: BTreeMap<String, String>,
-    #[serde(rename = "peerDependencies", default)]
-    pub peer_dependencies: BTreeMap<String, String>,
 }
 
 #[serde_as]
@@ -55,9 +51,7 @@ pub struct PackageMetadata {
 }
 
 #[tracing::instrument(name = "download_pkg_metadata")]
-pub async fn download_pkg_metadata(
-    pkg_name: &str,
-) -> Result<PackageMetadata, ServerError> {
+pub async fn download_pkg_metadata(pkg_name: &str) -> Result<PackageMetadata, ServerError> {
     let url: String = format!("https://registry.npmjs.org/{}", pkg_name);
     let client = get_client();
     let response = client

--- a/src/npm/package_data.rs
+++ b/src/npm/package_data.rs
@@ -1,0 +1,87 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use crate::app_error::ServerError;
+
+fn get_client() -> ClientWithMiddleware {
+    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+
+    let client_builder = reqwest::ClientBuilder::new()
+        .timeout(Duration::from_secs(120))
+        .deflate(true)
+        .gzip(true)
+        .brotli(true);
+    let base_client = client_builder
+        .build()
+        .expect("reqwest::ClientBuilder::build()");
+
+    ClientBuilder::new(base_client)
+        .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+        .build()
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct PackageDist {
+    pub tarball: String,
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct PackageVersion {
+    pub dist: PackageDist,
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct PackageMetadata {
+    pub name: String,
+
+    #[serde(rename = "dist-tags")]
+    pub dist_tags: Option<BTreeMap<String, String>>,
+
+    pub versions: Option<BTreeMap<String, PackageVersion>>,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct NormalizedPackageMetadata {
+    pub name: String,
+    pub dist_tags: Option<BTreeMap<String, String>>,
+    pub versions: Option<BTreeMap<String, String>>,
+}
+
+#[tracing::instrument(name = "download_pkg_metadata")]
+pub async fn download_pkg_metadata(
+    pkg_name: &str,
+) -> Result<NormalizedPackageMetadata, ServerError> {
+    let url: String = format!("https://registry.npmjs.org/{}", pkg_name);
+    let client = get_client();
+    let response = client.get(&url).send().await?;
+    let response_status = response.status();
+    if !response_status.is_success() {
+        return Err(ServerError::PackageMetadataDownloadError {
+            status_code: response_status.as_u16(),
+            url: String::from(&url),
+        });
+    }
+
+    let txt = response.text().await?;
+    let metadata: PackageMetadata = serde_json::from_str(&txt)?;
+
+    let mut versions = BTreeMap::new();
+    if let Some(raw_versions) = metadata.versions {
+        for (version, version_data) in raw_versions {
+            versions.insert(version, version_data.dist.tarball);
+        }
+    }
+
+    Ok(NormalizedPackageMetadata {
+        name: metadata.name,
+        dist_tags: metadata.dist_tags,
+        versions: Some(versions),
+    })
+}

--- a/src/npm_replicator/types/document.rs
+++ b/src/npm_replicator/types/document.rs
@@ -82,15 +82,11 @@ impl MinimalPackageData {
             last_updated: Some(secs_since_epoch()),
         };
         for (key, value) in raw.versions {
-            let mut dependencies = value.dependencies;
-            for (name, version) in value.dev_dependencies {
-                dependencies.insert(name, version);
-            }
             data.versions.insert(
                 key,
                 MinimalPackageVersionData {
                     tarball: value.dist.tarball,
-                    dependencies,
+                    dependencies: value.dependencies,
                 },
             );
         }

--- a/src/npm_replicator/types/document.rs
+++ b/src/npm_replicator/types/document.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError};
 use std::collections::BTreeMap;
 
+use crate::utils::time::secs_since_epoch;
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct DocumentPackageDist {
     pub tarball: String,
@@ -44,6 +46,8 @@ pub struct MinimalPackageData {
     pub name: String,
     pub dist_tags: BTreeMap<String, String>,
     pub versions: BTreeMap<String, MinimalPackageVersionData>,
+    // Seconds since the epoch
+    pub last_updated: Option<u64>,
 }
 
 impl MinimalPackageData {
@@ -52,6 +56,7 @@ impl MinimalPackageData {
             name: raw.id,
             dist_tags: raw.dist_tags.unwrap_or_default(),
             versions: BTreeMap::new(),
+            last_updated: Some(secs_since_epoch()),
         };
         for (key, value) in raw.versions.unwrap_or_default() {
             let mut dependencies = value.dependencies.unwrap_or_default();

--- a/src/router/routes_v2/route_deps.rs
+++ b/src/router/routes_v2/route_deps.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use warp::{Filter, Rejection, Reply};
 
 use crate::app_error::{AppResult, ServerError};
-use crate::npm::dep_tree_builder::{DepRange, DepRequest, DepTreeBuilder, ResolutionsMap};
+use crate::npm::dep_tree_builder::{DepRequest, DepTreeBuilder, ResolutionsMap};
 use crate::npm_replicator::registry::NpmRocksDB;
 use crate::package::process::parse_package_specifier_no_validation;
 use crate::router::utils::decode_base64;
@@ -17,8 +17,7 @@ fn parse_query(query: String) -> Result<HashSet<DepRequest>, ServerError> {
     let mut dep_requests: HashSet<DepRequest> = HashSet::new();
     for part in parts {
         let (name, version) = parse_package_specifier_no_validation(part)?;
-        let parsed_range = DepRange::parse(version);
-        dep_requests.insert(DepRequest::new(name, parsed_range));
+        dep_requests.insert(DepRequest::from_name_version(name, version)?);
     }
     Ok(dep_requests)
 }

--- a/src/router/routes_v2/route_deps.rs
+++ b/src/router/routes_v2/route_deps.rs
@@ -75,10 +75,7 @@ async fn get_reply(
                         return Err(ServerError::PackageNotFound(new_pkg_name));
                     }
                     last_failed_pkg_name = Some(new_pkg_name.clone());
-                    let fetch_res = cloned_npm_db.fetch_missing_pkg(&new_pkg_name).await;
-                    if !fetch_res.is_ok() {
-                        return Err(ServerError::PackageNotFound(new_pkg_name));
-                    }
+                    cloned_npm_db.fetch_missing_pkg(&new_pkg_name).await?;
                 }
             }
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod test_utils;
 pub mod msgpack;
+pub mod time;

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -1,0 +1,9 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn secs_since_epoch() -> u64 {
+    let start = SystemTime::now();
+    let since_the_epoch = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+    since_the_epoch.as_secs()
+}


### PR DESCRIPTION
Try resolving and if any package is missing, download the package => retry resolving => ...

This is usually not needed at all, but as the sync is sometimes not perfect we need it as a fallback