### PR TITLE
Feat/use ubuntu docker iamge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY . .
 RUN cargo build --release
 
 
-FROM debian:bookworm-20240211-slim
+FROM ubuntu:23:10
 
 RUN apt-get update \
     && apt-get install -y ca-certificates tzdata dumb-init \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY . .
 RUN cargo build --release
 
 
-FROM ubuntu:23:10
+FROM ubuntu:23.10
 
 RUN apt-get update \
     && apt-get install -y ca-certificates tzdata dumb-init \


### PR DESCRIPTION
Use `ubuntu:23.10` image instead of debian for fixing vulnerabilities