### PR TITLE
fix(image): remove default ubuntu user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ RUN apt-get update \
 EXPOSE 8080
 ENV APP_USER=appuser
 
-RUN groupadd $APP_USER \
+RUN userdel ubuntu \
+    && rm -rf /home/ubuntu \
+    && groupadd $APP_USER \
     && useradd --create-home -g $APP_USER $APP_USER
 
 WORKDIR /home/appuser


### PR DESCRIPTION
This PR removes the default `ubuntu` user that comes with the `ubuntu` image, with a uid:gid of `1000:1000`, and interferes with creating the `appuser` user, that is expected to have the same uid:gid.