### PR TITLE
fix(image): only copy the binary, without all other build artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN userdel ubuntu \
 
 WORKDIR /home/appuser
 
-COPY --chown=$APP_USER:$APP_USER --from=builder /app/sandpack-cdn/target/release/  ./
+COPY --chown=$APP_USER:$APP_USER --from=builder /app/sandpack-cdn/target/release/sandpack-cdn ./
 
 USER $APP_USER
 RUN mkdir /home/$APP_USER/npm_db


### PR DESCRIPTION
This PR only copies the `sandpack-cdn` binary, without all other build artifacts, that are unneeded, and make the image (a lot) bigger:

![image](https://github.com/codesandbox/sandpack-cdn/assets/2083930/49c319b6-a704-409c-a926-767210e8ea51)

Related Slack thread: https://codesandboxapp.slack.com/archives/C016L0W2Y0Y/p1710415243627799 .
